### PR TITLE
Don't process URL fragments as parameters if in the Drupal Admin Overlay

### DIFF
--- a/islandora_internet_archive_bookreader.drush.inc
+++ b/islandora_internet_archive_bookreader.drush.inc
@@ -13,7 +13,7 @@ define('IABOOKREADER_DOWNLOAD_URI', 'https://github.com/internetarchive/bookread
 /**
  * The original extracted directory from the zip file.
  */
-define('IABOOKREADER_ORIGINAL_DIR', 'internet_archive_bookreader-2.0.2');
+define('IABOOKREADER_ORIGINAL_DIR', 'bookreader-2.0.2');
 
 /**
  * Implements hook_drush_command().

--- a/js/islandora_book_reader.js
+++ b/js/islandora_book_reader.js
@@ -944,8 +944,16 @@ IslandoraBookReader.prototype.blankFulltextDiv = function() {
             whiteSpace: 'nowrap'
           },
         }
-      )
-      ;
+      );
   }
-  
+  // Overrides paramsFromFragment().
+  //______________________________________________________________________________
+  IslandoraBookReader.prototype.paramsFromFragment = function(urlFragment) {
+     if (/#overlay=/.test(urlFragment)) {
+       // We are on the Drupal Admin overlay. return instead of processing the Params.
+       return;
+     }
+     // Call the original Method.
+     return BookReader.prototype.paramsFromFragment(urlFragment);
+   }
 })(jQuery);


### PR DESCRIPTION
@whikloj saved the day.
